### PR TITLE
Validation errors

### DIFF
--- a/manifests/ca.pp
+++ b/manifests/ca.pp
@@ -40,7 +40,7 @@ define ca_cert::ca (
   validate_string($source)
   validate_bool($verify_https_cert)
 
-  if ($ensure == 'trusted' or $ensure == 'disrusted') and $source == 'text' and $ca_text == undef {
+  if ($ensure == 'trusted' or $ensure == 'distrusted') and $source == 'text' and $ca_text == undef {
     fail('ca_text is required if source is set to text')
   }
 

--- a/manifests/ca.pp
+++ b/manifests/ca.pp
@@ -40,7 +40,7 @@ define ca_cert::ca (
   validate_string($source)
   validate_bool($verify_https_cert)
 
-  if ($ensure == 'trusted' or $ensure == 'distrusted') and $source == 'text' and $ca_text == undef {
+  if ($ensure == 'trusted' or $ensure == 'distrusted') and $source == 'text' and !is_string($ca_text) {
     fail('ca_text is required if source is set to text')
   }
 


### PR DESCRIPTION
1. There was a typo in "distrust" that would have prevented string matching.

2. This change switched from a string comparison ($ca_text == undef) to using stdlib's "is_string" validator. Without this change certain keys could create invalid byte sequence
errors due to the string comparison:

> puppet Error: Could not retrieve catalog from remote server: Error
400 on SERVER: invalid byte sequence in US-ASCII

