### PR TITLE
Added the files directory and added an example of using "source => 'puppet:///module'"

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,13 @@ ca_cert::ca { 'GlobalSign-OrgSSL-Intermediate':
   ensure => 'trusted',
   source => 'http://secure.globalsign.com/cacert/gsorganizationvalsha2g2r1.crt',
 }
+
+Add a certificate when you have a the certificate file locally.
+
+ca_cert::ca { 'gd_bundle-g2.crt':
+  ensure => 'trusted',
+  source => 'puppet:///modules/ca_cert/gd_bundle-g2.crt',
+}
 ```
 
 `ca_cert::ca` supports 3 parameters:

--- a/files/readme.txt
+++ b/files/readme.txt
@@ -1,0 +1,1 @@
+# This file is just a placeholder so that the ../files directory gets added to the project.


### PR DESCRIPTION
I would think that admins would want to place the certificates that they have contained in files in the puppet-ca_cert/files directory for general good housekeeping. I created the files directory along with a placeholder (junk) file since GIT doesn't support the checking in of empty directories.

Also, I added an example of how to use the puppet:/// protocol type for local (file based) certificates.