### PR TITLE
Use stdlib ensure_packages for installing ca-certificates package

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -70,7 +70,7 @@ class ca_cert (
   }
 
   if $install_package == true {
-    if $package_ensure == present {
+    if $package_ensure == present or $package_ensure == installed {
       ensure_packages(['ca-certificates'])
     }
     else {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -70,8 +70,13 @@ class ca_cert (
   }
 
   if $install_package == true {
-    package { 'ca-certificates':
-      ensure => $package_ensure,
+    if $package_ensure == present {
+      ensure_packages(['ca-certificates'])
+    }
+    else {
+      package { 'ca-certificates':
+        ensure => $package_ensure,
+      }
     }
   }
 


### PR DESCRIPTION
Hi there!

Ran into a common issue with installing packages in Puppet for duplicate resources when using the puppet/nodejs module:
https://github.com/voxpupuli/puppet-nodejs/blob/master/manifests/repo/nodesource/apt.pp#L9

```
Feb 22 14:17:18 exampleserver puppet-agent[18599]: Could not retrieve catalog from remote server: Error 400 on SERVER: Evaluation Error: Error while evaluating a Resource Statement, Duplicate declaration: Package[ca-certificates] is already declared; cannot redeclare at /etc/puppetlabs/code/environments/staging/modules/ca_cert/manifests/init.pp:70 at /etc/puppetlabs/code/environments/staging/modules/ca_cert/manifests/init.pp:70:5 on node exampleserver.example.com
```

For now we've opted to set `install_package: false` with this module but it makes our setup more complicated than necessary. Puppetlabs stdlib provides `ensure_packages` to consistently handle this situation (available since stdlib 2.6):
https://forge.puppetlabs.com/puppetlabs/stdlib#ensure_packages

Can you please switch to `ensure_packages` and release? Very much appreciated. Thanks!