### PR TITLE
Add Support for OpenSuSE 13 and 42 Leap

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,4 +78,4 @@ ca_cert::ca { 'GlobalSign-OrgSSL-Intermediate':
 Supported Platforms
 -------------------
 
-This module has been tested on Ubuntu 14.04, Ubuntu 12.04, CentOS 6, SLES 11, and SLES 12.
+This module has been tested on Ubuntu 14.04, Ubuntu 12.04, CentOS 6, SLES 11, SLES 12, OpenSuSE 13.1, OpenSuSE 13.2 and OpenSuSE 42.1 Leap.

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -30,7 +30,7 @@ class ca_cert::params {
         $update_cmd        = 'c_rehash'
         $ca_file_extension = 'pem'
       }
-      elsif $::operatingsystemmajrelease == '12' {
+      elsif $::operatingsystemmajrelease >= '12' {
         $trusted_cert_dir    = '/etc/pki/trust/anchors'
         $distrusted_cert_dir = '/etc/pki/trust/blacklist'
         $update_cmd          = 'update-ca-certificates'

--- a/metadata.json
+++ b/metadata.json
@@ -24,6 +24,13 @@
       ]
     },
     {
+      "operatingsystem": "OpenSuSE",
+      "operatingsystemrelease": [
+        "13.2",
+        "42.1"
+      ]
+    },
+    {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
         "12.04",


### PR DESCRIPTION
The mechanism for ca updates works on opensuse 13 and 42 as well. (tested). Maybe in 42.2 something will change, but thats unlikely and even when...we can still update the manifest then.