### PR TITLE
Enable force update for RedHat update-ca-trust command.

### DIFF
--- a/manifests/update.pp
+++ b/manifests/update.pp
@@ -4,7 +4,7 @@ class ca_cert::update {
 
   if $::osfamily == 'RedHat' {
     exec { 'enable_ca_trust':
-      command   => 'update-ca-trust enable',
+      command   => 'update-ca-trust force-enable',
       logoutput => 'on_failure',
       path      => ['/usr/sbin', '/usr/bin', '/bin'],
       onlyif    => 'update-ca-trust check | grep DISABLED',

--- a/spec/classes/update_spec.rb
+++ b/spec/classes/update_spec.rb
@@ -33,7 +33,7 @@ describe 'ca_cert::update', :type => :class do
     it_behaves_like 'compiles and includes params class' do
     end
     it { is_expected.to contain_exec('enable_ca_trust').with(
-      :command => 'update-ca-trust enable',
+      :command => 'update-ca-trust force-enable',
     ) }
     it { is_expected.to contain_exec('ca_cert_update').with(
       :command     => 'update-ca-trust extract',


### PR DESCRIPTION
If the user has made changes to the classic configuration files this will discard those changes and forcefully switch to most recent set of standard CA certificates and trust.
