### PR TITLE
Add username and password for authenticated remote endpoints

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,31 +6,31 @@ script:
 matrix:
   fast_finish: true
   include:
-  - rvm: 2.1.6
+  - rvm: 2.3.1
     dist: trusty
     env: PUPPET_INSTALL_TYPE=agent BEAKER_debug=true
     script: bundle exec rake beaker
     services: docker
     sudo: required
-  - rvm: 2.1.6
+  - rvm: 2.3.1
     dist: trusty
     env: PUPPET_INSTALL_TYPE=agent BEAKER_debug=true BEAKER_set=ubuntu-16.04
     script: bundle exec rake beaker
     services: docker
     sudo: required
-  - rvm: 2.1.6
+  - rvm: 2.3.1
     dist: trusty
     env: PUPPET_INSTALL_TYPE=agent BEAKER_debug=true BEAKER_set=centos-7
     script: bundle exec rake beaker
     services: docker
     sudo: required
-  - rvm: 2.1.6
+  - rvm: 2.3.1
     bundler_args: --without system_tests
     env: PUPPET_GEM_VERSION="~> 4.5" STRICT_VARIABLES="yes"
-  - rvm: 2.1.6
+  - rvm: 2.3.1
     bundler_args: --without system_tests
     env: PUPPET_GEM_VERSION="~> 3.5" FUTURE_PARSER="yes"
-  - rvm: 2.1.6
+  - rvm: 2.3.1
     bundler_args: --without system_tests
     env: PUPPET_GEM_VERSION="~> 3.8"
   - rvm: 1.9.3

--- a/manifests/ca.pp
+++ b/manifests/ca.pp
@@ -126,7 +126,7 @@ define ca_cert::ca (
             if ! $password {
               fail('Password parameter must be set when username is set')
             }
-            $wget_username = "--username '${username}'"
+            $wget_username = "--user '${username}'"
           } else {
             $wget_username = ''
           }

--- a/manifests/ca.pp
+++ b/manifests/ca.pp
@@ -22,10 +22,10 @@
 #   source. (defaults to true)
 # [*username*]
 #   Username for retrieving a certificate from an authenticated http, https or
-#   ftp source. (optional)
+#   ftp source. (required if password is set)
 # [*password*]
 #   Password for retrieving a certificate from an authenticated http, https or
-#   ftp source. (optional)
+#   ftp source. (required if username is set)
 #
 # === Examples
 #

--- a/manifests/ca.pp
+++ b/manifests/ca.pp
@@ -52,6 +52,8 @@ define ca_cert::ca (
   include ::ca_cert::update
 
   validate_string($source)
+  validate_string($username)
+  validate_string($password)
   validate_bool($verify_https_cert)
 
   if ($ensure == 'trusted' or $ensure == 'distrusted') and $source == 'text' and !is_string($ca_text) {

--- a/manifests/ca.pp
+++ b/manifests/ca.pp
@@ -20,11 +20,23 @@
 # [*verify_https_cert*]
 #   When retrieving a certificate whether or not to validate the CA of the
 #   source. (defaults to true)
+# [*username*]
+#   Username for retrieving a certificate from an authenticated http, https or
+#   ftp source. (optional)
+# [*password*]
+#   Password for retrieving a certificate from an authenticated http, https or
+#   ftp source. (optional)
 #
 # === Examples
 #
 # ca_cert::ca { 'globalsign_org_intermediate':
 #   source => 'http://secure.globalsign.com/cacert/gsorganizationvalsha2g2r1.crt',
+# }
+#
+# ca_cert::ca { 'internal_rootca':
+#   source   => 'http://ca.example.com/ca/root.crt',
+#   username => 'puppet',
+#   password => '$3cureP455W0rd',
 # }
 
 define ca_cert::ca (
@@ -32,6 +44,8 @@ define ca_cert::ca (
   $source            = 'text',
   $ensure            = 'trusted',
   $verify_https_cert = true,
+  $username          = undef,
+  $password          = undef,
 ) {
 
   include ::ca_cert::params
@@ -106,9 +120,24 @@ define ca_cert::ca (
             true  => '',
             false => '--no-check-certificate',
           }
+          if $username {
+            if ! $password {
+              fail('Password parameter must be set when username is set')
+            }
+            $wget_username = "--username '${username}'"
+          } else {
+            $wget_username = ''
+          }
+          if $password {
+            if ! $username {
+              fail('Username parameter must be set when password is set')
+            }
+            $wget_password = "--password '${password}'"
+          } else {
+            $wget_password = ''
+          }
           exec { "get_${resource_name}":
-            command =>
-              "wget ${verify_https} -O ${ca_cert} ${source} 2> /dev/null",
+            command => "wget ${verify_https} ${wget_username} ${wget_password} -O ${ca_cert} ${source} 2> /dev/null",
             path    => ['/usr/bin', '/bin'],
             creates => $ca_cert,
             notify  => Exec['ca_cert_update'],

--- a/spec/defines/ca_spec.rb
+++ b/spec/defines/ca_spec.rb
@@ -155,7 +155,7 @@ K1pp74P1S8SqtCr4fKGxhZSM9AyHDPSsQPhZSZg=
         end
         it { is_expected.to contain_exec("get_Globalsign_Org_Intermediate.crt").with(
             'creates' => DEBIAN_CA_FILE,
-            'command' => "wget  --username '#{USERNAME}' --password '#{PASSWORD}' -O #{DEBIAN_CA_FILE} #{HTTP_URL} 2> /dev/null",
+            'command' => "wget  --user '#{USERNAME}' --password '#{PASSWORD}' -O #{DEBIAN_CA_FILE} #{HTTP_URL} 2> /dev/null",
           )
         }
         it { is_expected.not_to contain_file(DEBIAN_CA_FILE) }
@@ -224,7 +224,7 @@ K1pp74P1S8SqtCr4fKGxhZSM9AyHDPSsQPhZSZg=
         end
         it { is_expected.to contain_exec("get_Globalsign_Org_Intermediate.crt").with(
             'creates' => REDHAT_CA_FILE,
-            'command' => "wget  --username '#{USERNAME}' --password '#{PASSWORD}' -O #{REDHAT_CA_FILE} #{HTTP_URL} 2> /dev/null",
+            'command' => "wget  --user '#{USERNAME}' --password '#{PASSWORD}' -O #{REDHAT_CA_FILE} #{HTTP_URL} 2> /dev/null",
           )
         }
         it { is_expected.not_to contain_file(REDHAT_CA_FILE) }
@@ -302,7 +302,7 @@ K1pp74P1S8SqtCr4fKGxhZSM9AyHDPSsQPhZSZg=
 
         it { is_expected.to contain_exec("get_Globalsign_Org_Intermediate.pem").with(
             'creates' => SUSE_11_CA_FILE,
-            'command' => "wget  --username '#{USERNAME}' --password '#{PASSWORD}' -O #{SUSE_11_CA_FILE} #{SUSE_11_HTTP_URL} 2> /dev/null",
+            'command' => "wget  --user '#{USERNAME}' --password '#{PASSWORD}' -O #{SUSE_11_CA_FILE} #{SUSE_11_HTTP_URL} 2> /dev/null",
           ) }
         it { is_expected.not_to contain_file(SUSE_11_CA_FILE) }
       end
@@ -381,7 +381,7 @@ K1pp74P1S8SqtCr4fKGxhZSM9AyHDPSsQPhZSZg=
         end
         it { is_expected.to contain_exec("get_Globalsign_Org_Intermediate.crt").with(
             'creates' => SUSE_12_CA_FILE,
-            'command' => "wget  --username '#{USERNAME}' --password '#{PASSWORD}' -O #{SUSE_12_CA_FILE} #{HTTP_URL} 2> /dev/null",
+            'command' => "wget  --user '#{USERNAME}' --password '#{PASSWORD}' -O #{SUSE_12_CA_FILE} #{HTTP_URL} 2> /dev/null",
           )
         }
         it { is_expected.not_to contain_file(SUSE_11_CA_FILE) }


### PR DESCRIPTION
Hi,

I've added a username and password parameter. These allow you to get certificates from remote servers protected by user / pass authentication.

I've added test cases for this to the spec tests.

Any feedback is appreciated. 

Thanks!

Tim