### PR TITLE
Do not purge managed CA's

### DIFF
--- a/manifests/ca.pp
+++ b/manifests/ca.pp
@@ -104,6 +104,9 @@ define ca_cert::ca (
             path    => ['/usr/bin', '/bin'],
             creates => $ca_cert,
             notify  => Exec['ca_cert_update'],
+          } ->
+          file {$ca_cert:
+            replace => false,
           }
         }
         'file': {


### PR DESCRIPTION
This does nothing on the file. This just allows Puppet to be aware of the
existence of this file and avoid purging it if `purge_unmanaged_CAs` is
st to `true`.

Closes #29