### PR TITLE
Add `curl` and `remote_file` support

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Optional parameters:
   * `ca_certs`: A hash of certificates you would like added. These may also be defined
                 by declaring `ca_cert::ca` once for each certificate.
   * `download_with`: A string that defines what program to download the certificate with.
-                     The available values are `wget` (default).
+                     The available values are `wget` (default) and `curl`.
 
 ### ca_cert::ca
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ Optional parameters:
   * `ca_certs`: A hash of certificates you would like added. These may also be defined
                 by declaring `ca_cert::ca` once for each certificate.
   * `download_with`: A string that defines what program to download the certificate with.
-                     The available values are `wget` (default) and `curl`.
+                     The available values are `wget` (default), `curl` and `remote_file`.
+                     Note that `remote_file` requires [lwf/puppet-remote_file](https://github.com/lwf/puppet-remote_file).
 
 ### ca_cert::ca
 
@@ -76,6 +77,10 @@ ca_cert::ca { 'GlobalSign-OrgSSL-Intermediate':
   * `verify_https_cert`: If a certificate is retrieved over HTTPS, whether or not the
                          server's certificate should be validated against the fetching
                          machine's trusted CA list or not. (defaults to true)
+  * `checksum`: The md5sum of the CA certificate. Only used when `download_with` is
+                set to `remote_file`. The file will be downloaded if the checksum does not match this value.
+                See the `checksum` parameter at [lwf/puppet-remote_file](https://github.com/lwf/puppet-remote_file)
+                for details.
 
 Supported Platforms
 -------------------

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ Optional parameters:
                        module to manage other installed CA certificates. (defaults to true)
   * `ca_certs`: A hash of certificates you would like added. These may also be defined
                 by declaring `ca_cert::ca` once for each certificate.
+  * `download_with`: A string that defines what program to download the certificate with.
+                     The available values are `wget` (default).
 
 ### ca_cert::ca
 

--- a/manifests/ca.pp
+++ b/manifests/ca.pp
@@ -101,6 +101,13 @@ define ca_cert::ca (
               }
               $get_command = "wget ${verify_https} -O '${ca_cert}' '${source}' 2> /dev/null || rm -f '${ca_cert}'"
             }
+            'curl': {
+              $verify_https = $verify_https_cert ? {
+                true  => '',
+                false => '--insecure',
+              }
+              $get_command = "curl ${verify_https} '${source}' > '${ca_cert}' 2> /dev/null || rm -f '${ca_cert}'"
+            }
             default: {
               fail("Unknown download provider: \"${::ca_cert::download_with}\"")
             }

--- a/manifests/ca.pp
+++ b/manifests/ca.pp
@@ -113,11 +113,12 @@ define ca_cert::ca (
             }
             'remote_file': {
               remote_file { $ca_cert:
-                ensure   => present,
-                source   => $source,
-                checksum => $checksum,
-                notify   => Exec['ca_cert_update'],
-                mode     => '0644',
+                ensure      => present,
+                source      => $source,
+                checksum    => $checksum,
+                notify      => Exec['ca_cert_update'],
+                mode        => '0644',
+                verify_peer => $verify_https_cert,
               }
             }
             default: {

--- a/manifests/ca.pp
+++ b/manifests/ca.pp
@@ -20,6 +20,8 @@
 # [*verify_https_cert*]
 #   When retrieving a certificate whether or not to validate the CA of the
 #   source. (defaults to true)
+# [*checksum*]
+#   The md5sum of the file. Only used if $::ca_cert::download_with is 'remote_file'.
 #
 # === Examples
 #
@@ -32,6 +34,7 @@ define ca_cert::ca (
   $source            = 'text',
   $ensure            = 'trusted',
   $verify_https_cert = true,
+  $checksum          = undef,
 ) {
 
   include ::ca_cert::params
@@ -107,6 +110,15 @@ define ca_cert::ca (
                 false => '--insecure',
               }
               $get_command = "curl ${verify_https} '${source}' > '${ca_cert}' 2> /dev/null || rm -f '${ca_cert}'"
+            }
+            'remote_file': {
+              remote_file { $ca_cert:
+                ensure   => present,
+                source   => $source,
+                checksum => $checksum,
+                notify   => Exec['ca_cert_update'],
+                mode     => '0644',
+              }
             }
             default: {
               fail("Unknown download provider: \"${::ca_cert::download_with}\"")

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -23,6 +23,10 @@
 #   declaration
 # [*package_ensure*]
 #   The ensure parameter to pass to the package resource
+# [*download_with*]
+#   Choose what program to download the certificate with. Supported programs
+#   are 'wget' (default).
+#
 #
 # === Examples
 #
@@ -43,6 +47,7 @@ class ca_cert (
   $ca_certs            = {},
   $package_ensure      = present,
   $package_name        = $ca_cert::params::package_name,
+  $download_with       = $ca_cert::params::download_with,
 ) inherits ca_cert::params {
 
   include ::ca_cert::params

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -25,7 +25,7 @@
 #   The ensure parameter to pass to the package resource
 # [*download_with*]
 #   Choose what program to download the certificate with. Supported programs
-#   are 'wget' (default) and 'curl'.
+#   are 'wget' (default), 'curl' and `remote_file`.
 #
 #
 # === Examples

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -25,7 +25,7 @@
 #   The ensure parameter to pass to the package resource
 # [*download_with*]
 #   Choose what program to download the certificate with. Supported programs
-#   are 'wget' (default).
+#   are 'wget' (default) and 'curl'.
 #
 #
 # === Examples

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,5 +1,6 @@
 # Private class
 class ca_cert::params {
+  $download_with = 'wget'
   case $::osfamily {
     'Debian': {
       $trusted_cert_dir  = '/usr/local/share/ca-certificates'


### PR DESCRIPTION
Each commit provides a new feature and the PR closes #28 :

1. Feature: new `download_with` parameter
1. Feature: `download_with => 'curl'` is available
1. Feature: `download_with => 'remote_file'` is available

Note that I did not touch the tests; there might be some work on that part but my knowledge is limited on Gem/Rake.

Please tell me if you like it or not. If you have a question or request, do not hesitate to comment. I'm away from the keyboard this week-end. I will be back Monday.

