### PR TITLE
Allow Setting Ca file mode

### DIFF
--- a/manifests/ca.pp
+++ b/manifests/ca.pp
@@ -20,6 +20,10 @@
 # [*verify_https_cert*]
 #   When retrieving a certificate whether or not to validate the CA of the
 #   source. (defaults to true)
+# [*ca_file_mode*]
+#   The installed CA certificate's POSIX filesystem permissions. This uses
+#   the same syntax as Puppet's native file resource's "mode" parameter.
+#   (defaults to '0444', i.e. world-readable)
 #
 # === Examples
 #
@@ -32,6 +36,7 @@ define ca_cert::ca (
   $source            = 'text',
   $ensure            = 'trusted',
   $verify_https_cert = true,
+  $ca_file_mode      = $ca_cert::params::ca_file_mode,
 ) {
 
   include ::ca_cert::params
@@ -89,6 +94,7 @@ define ca_cert::ca (
             path    => $ca_cert,
             owner   => 'root',
             group   => 'root',
+            mode    => $ca_file_mode,
             require => Package[$ca_cert::params::package_name],
             notify  => Exec['ca_cert_update'],
           }
@@ -114,6 +120,7 @@ define ca_cert::ca (
             path    => $ca_cert,
             owner   => 'root',
             group   => 'root',
+            mode    => $ca_file_mode,
             require => Package[$ca_cert::params::package_name],
             notify  => Exec['ca_cert_update'],
           }
@@ -125,6 +132,7 @@ define ca_cert::ca (
             path    => $ca_cert,
             owner   => 'root',
             group   => 'root',
+            mode    => $ca_file_mode,
             require => Package[$ca_cert::params::package_name],
             notify  => Exec['ca_cert_update'],
           }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -58,13 +58,15 @@ class ca_cert (
   }
 
   $trusted_cert_dir = $ca_cert::params::trusted_cert_dir
-  $cert_dir_group = $ca_cert::params::cert_dir_group
+  $cert_dir_group   = $ca_cert::params::cert_dir_group
+  $cert_dir_mode    = $ca_cert::params::cert_dir_mode
 
   file { 'trusted_certs':
     ensure  => directory,
     path    => $trusted_cert_dir,
     owner   => 'root',
     group   => $cert_dir_group,
+    mode    => $cert_dir_mode,
     purge   => $purge_unmanaged_CAs,
     recurse => $purge_unmanaged_CAs,
     notify  => Exec['ca_cert_update'],

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -5,6 +5,8 @@ class ca_cert::params {
       $trusted_cert_dir  = '/usr/local/share/ca-certificates'
       $update_cmd        = 'update-ca-certificates'
       $cert_dir_group    = 'staff'
+      $cert_dir_mode     = '2665'
+      $ca_file_mode      = '0444'
       $ca_file_extension = 'crt'
       $package_name      = 'ca-certificates'
     }
@@ -13,6 +15,8 @@ class ca_cert::params {
       $distrusted_cert_dir = '/etc/pki/ca-trust/source/blacklist'
       $update_cmd          = 'update-ca-trust extract'
       $cert_dir_group      = 'root'
+      $cert_dir_mode       = '0555'
+      $ca_file_mode        = '0444'
       $ca_file_extension   = 'crt'
       $package_name        = 'ca-certificates'
     }
@@ -21,6 +25,8 @@ class ca_cert::params {
       $distrusted_cert_dir = '/etc/ca-certificates/trust-source/blacklist'
       $update_cmd          = 'trust extract-compat'
       $cert_dir_group      = 'root'
+      $cert_dir_mode       = '0555'
+      $ca_file_mode        = '0444'
       $ca_file_extension   = 'crt'
       $package_name        = 'ca-certificates'
     }
@@ -39,6 +45,8 @@ class ca_cert::params {
         $package_name        = 'ca-certificates'
       }
       $cert_dir_group        = 'root'
+      $cert_dir_mode         = '0555'
+      $ca_file_mode          = '0444'
     }
     default: {
       fail("Unsupported osfamily (${::osfamily})")

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -5,10 +5,20 @@ class ca_cert::params {
       $trusted_cert_dir  = '/usr/local/share/ca-certificates'
       $update_cmd        = 'update-ca-certificates'
       $cert_dir_group    = 'staff'
-      $cert_dir_mode     = '2665'
       $ca_file_mode      = '0444'
       $ca_file_extension = 'crt'
       $package_name      = 'ca-certificates'
+      case $::operatingsystem {
+        'Ubuntu': {
+          $cert_dir_mode     = '0755'
+        }
+        'Debian': {
+          $cert_dir_mode     = '2665'
+        }
+        default: {
+          fail("Unsupported operatingsystem (${::operatingsystem})")
+        }
+      }
     }
     'RedHat': {
       $trusted_cert_dir    = '/etc/pki/ca-trust/source/anchors'

--- a/spec/classes/ca_cert_spec.rb
+++ b/spec/classes/ca_cert_spec.rb
@@ -11,6 +11,7 @@ describe 'ca_cert', :type => :class do
     let :facts do
       {
         :osfamily => 'Debian',
+        :operatingsystem => 'Ubuntu',
       }
     end
 

--- a/spec/classes/update_spec.rb
+++ b/spec/classes/update_spec.rb
@@ -11,6 +11,7 @@ describe 'ca_cert::update', :type => :class do
     let :facts do
       {
         :osfamily => 'Debian',
+        :operatingsystem => 'Ubuntu'
       }
     end
 


### PR DESCRIPTION
Allow Setting Ca file mode per certificate. Tested with Debian 8.
(i'm only submitting the PR, original work done by tmaher)