### PR TITLE
Don't run enable_ca_trust on EL7

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,6 +1,6 @@
 fixtures:
   repositories:
-    stdlib: "git://github.com/puppetlabs/puppetlabs-stdlib.git"
-    remote_file: "git://github.com/lwf/puppet-remote_file.git"
+    stdlib: "https://github.com/puppetlabs/puppetlabs-stdlib.git"
+    remote_file: "https://github.com/lwf/puppet-remote_file.git"
   symlinks:
     ca_cert: "#{source_dir}"

--- a/manifests/update.pp
+++ b/manifests/update.pp
@@ -2,7 +2,7 @@
 class ca_cert::update {
   include ::ca_cert::params
 
-  if $::osfamily == 'RedHat' {
+  if ($::osfamily == 'RedHat' and versioncmp($::operatingsystemrelease, '7') < 0) {
     exec { 'enable_ca_trust':
       command   => 'update-ca-trust enable',
       logoutput => 'on_failure',

--- a/metadata.json
+++ b/metadata.json
@@ -12,24 +12,24 @@
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
-        "5.0",
-        "6.0",
-        "7.0"
+        "5",
+        "6",
+        "7"
       ]
     },
     {
-      "operatingsystem": "Suse",
+      "operatingsystem": "SLES",
       "operatingsystemrelease": [
-        "10.0",
-        "11.0",
-        "12.0"
+        "10",
+        "11",
+        "12"
       ]
     },
     {
       "operatingsystem": "OpenSuSE",
       "operatingsystemrelease": [
-        "13.2",
-        "42.1"
+        "13",
+        "42"
       ]
     },
     {
@@ -41,10 +41,7 @@
       ]
     },
     {
-      "operatingsystem": "Archlinux",
-      "operatingsystemrelease": [
-        "4.x"
-      ]
+      "operatingsystem": "Archlinux"
     }
   ],
   "requirements": [

--- a/spec/classes/ca_cert_spec.rb
+++ b/spec/classes/ca_cert_spec.rb
@@ -46,6 +46,7 @@ describe 'ca_cert', :type => :class do
     let :facts do
       {
         :osfamily => 'RedHat',
+        :operatingsystemrelease => '7.0'
       }
     end
 

--- a/spec/defines/ca_spec.rb
+++ b/spec/defines/ca_spec.rb
@@ -55,6 +55,7 @@ K1pp74P1S8SqtCr4fKGxhZSM9AyHDPSsQPhZSZg=
     {
       :osfamily => 'RedHat',
       :operatingsystem => 'RedHat',
+      :operatingsystemrelease => '7.0'
     }
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,6 @@
 require 'puppetlabs_spec_helper/module_spec_helper'
+require 'rspec-puppet-facts'
+include RspecPuppetFacts
 
 RSpec.configure do |c|
   c.before :each do


### PR DESCRIPTION
`update-ca-trust` ignores all arguments on EL7 so `update-ca-trust
enable` and even `update-ca-trust check` (from the unless parameter)
actually perform an update.

Fixes #GH-38

I've converted the spec tests for that class to use rspec-puppet-facts.