### PR TITLE
Switch to non-deprecated calls

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -48,7 +48,7 @@ class ca_cert (
   include ::ca_cert::params
   include ::ca_cert::update
 
-  validate_legacy(Bool, 'validate_bool', $always_update_certs)
+  validate_legacy(Boolean, 'validate_bool', $always_update_certs)
   validate_legacy(Hash, 'validate_hash', $ca_certs)
 
   if $always_update_certs == true {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -48,8 +48,8 @@ class ca_cert (
   include ::ca_cert::params
   include ::ca_cert::update
 
-  validate_legacy($always_update_certs)
-  validate_legacy($ca_certs)
+  validate_legacy(Bool, 'validate_bool', $always_update_certs)
+  validate_legacy(Hash, 'validate_hash', $ca_certs)
 
   if $always_update_certs == true {
     Exec <| title=='ca_cert_update' |> {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -48,8 +48,8 @@ class ca_cert (
   include ::ca_cert::params
   include ::ca_cert::update
 
-  validate_bool($always_update_certs)
-  validate_hash($ca_certs)
+  validate_legacy($always_update_certs)
+  validate_legacy($ca_certs)
 
   if $always_update_certs == true {
     Exec <| title=='ca_cert_update' |> {


### PR DESCRIPTION
Utilize `validate_legacy` from stdlib