### PR TITLE
test ca_certs::ca factory from hiera data

### DIFF
--- a/spec/classes/ca_cert_spec.rb
+++ b/spec/classes/ca_cert_spec.rb
@@ -5,6 +5,8 @@ describe 'ca_cert', :type => :class do
   shared_examples 'compiles and includes params class' do
     it { should compile }
     it { should contain_class('ca_cert::params') }
+    it { should contain_ca_cert__ca('ca1') }
+    it { should contain_ca_cert__ca('ca2') }
   end
 
   context "on a Debian based OS" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,7 @@ require 'rspec-puppet-facts'
 include RspecPuppetFacts
 
 RSpec.configure do |c|
+  c.hiera_config = File.expand_path(File.join(__FILE__, '../fixtures/hiera.yaml'))
   c.before :each do
     # Ensure that we don't accidentally cache facts and environment
     # between test cases.


### PR DESCRIPTION
test for #50, test actually fails with
```     Failure/Error: it { should compile }
       dependency cycles found: (File[ca1.pem] => Ca_cert::Ca[ca1] => Class[Ca_cert] => Ca_cert::Ca[ca1] => File[ca1.pem])
```
before https://github.com/pcfens/puppet-ca_cert/commit/4495f405fb2a5e01fdd8015af792e69c443c661a