### PR TITLE
Fix dependency issue with dropping certificate

### DIFF
--- a/manifests/ca.pp
+++ b/manifests/ca.pp
@@ -43,6 +43,8 @@ define ca_cert::ca (
 ) {
 
   include ::ca_cert::params
+  include ::ca_cert::update
+  require ::ca_cert::enable
 
   if ($ensure == 'trusted' or $ensure == 'distrusted') and $source == 'text' and !is_string($ca_text) {
     fail('ca_text is required if source is set to text')

--- a/manifests/enable.pp
+++ b/manifests/enable.pp
@@ -1,0 +1,25 @@
+# Private class
+class ca_cert::enable {
+
+  include ::ca_cert::params
+
+  if ($::osfamily == 'RedHat' and versioncmp($::operatingsystemrelease, '7') < 0) { 
+    if $ca_cert::force_enable {
+      exec { 'enable_ca_trust':
+        command   => 'update-ca-trust force-enable',
+        logoutput => 'on_failure',
+        path      => ['/usr/sbin', '/usr/bin', '/bin'],
+        onlyif    => 'update-ca-trust check | grep DISABLED',
+      }
+    }
+    else {
+      exec { 'enable_ca_trust':
+        command   => 'update-ca-trust enable',
+        logoutput => 'on_failure',
+        path      => ['/usr/sbin', '/usr/bin', '/bin'],
+        onlyif    => 'update-ca-trust check | grep DISABLED',
+      }
+    }
+  }
+
+}

--- a/manifests/update.pp
+++ b/manifests/update.pp
@@ -1,27 +1,8 @@
 # Private class
 class ca_cert::update {
+  
   include ::ca_cert::params
-
-  if ($::osfamily == 'RedHat' and versioncmp($::operatingsystemrelease, '7') < 0) {
-    if $ca_cert::force_enable {
-      exec { 'enable_ca_trust':
-        command   => 'update-ca-trust force-enable',
-        logoutput => 'on_failure',
-        path      => ['/usr/sbin', '/usr/bin', '/bin'],
-        onlyif    => 'update-ca-trust check | grep DISABLED',
-        before    => Exec['ca_cert_update'],
-      }
-    }
-    else {
-      exec { 'enable_ca_trust':
-        command   => 'update-ca-trust enable',
-        logoutput => 'on_failure',
-        path      => ['/usr/sbin', '/usr/bin', '/bin'],
-        onlyif    => 'update-ca-trust check | grep DISABLED',
-        before    => Exec['ca_cert_update'],
-      }
-    }
-  }
+  require ::ca_cert::enable
 
   exec { 'ca_cert_update':
     command     => $ca_cert::params::update_cmd,
@@ -29,4 +10,5 @@ class ca_cert::update {
     refreshonly => true,
     path        => ['/usr/sbin', '/usr/bin', '/bin'],
   }
+
 }


### PR DESCRIPTION
Put enable_ca_trust into separate class ca_cert::enable and make
ca_cert::ca resource type dependent on ca_cert::enable. This is to
avoid situations where the certificate file was being dropped even
though enable_ca_trust failed. When the issue causing enable_ca_trust to
fail was corrected, update_ca_trust would not execute due to the
certificate file already being dropped and refreshonly being set on
update_ca_trust.

Fixes pcfens/puppet-ca_cert#054