### PR TITLE
fix tests for `force_enable` parameter

### DIFF
--- a/manifests/enable.pp
+++ b/manifests/enable.pp
@@ -1,7 +1,7 @@
 # Private class
 class ca_cert::enable {
 
-  include ::ca_cert::params
+  include ca_cert
 
   if ($::osfamily == 'RedHat' and versioncmp($::operatingsystemrelease, '7') < 0) {
     if $ca_cert::force_enable {

--- a/manifests/update.pp
+++ b/manifests/update.pp
@@ -1,8 +1,8 @@
 # Private class
 class ca_cert::update {
 
-  include ::ca_cert::params
-  require ::ca_cert::enable
+  require ca_cert
+  require ca_cert::enable
 
   exec { 'ca_cert_update':
     command     => $ca_cert::params::update_cmd,

--- a/spec/classes/update_spec.rb
+++ b/spec/classes/update_spec.rb
@@ -25,21 +25,14 @@ describe 'ca_cert::update', type: :class do
           it { is_expected.not_to contain_exec('enable_ca_trust') }
         else
           context 'with force_enable set to true' do
-            let :params do
-              {
-                force_enable: true,
-              }
+            let :pre_condition do
+              'class { "ca_cert": force_enable => true }'
             end
 
             it { is_expected.to contain_exec('enable_ca_trust').with_command('update-ca-trust force-enable') }
           end
-          context 'with force_enable set to false' do
-            let :params do
-              {
-                force_enable: false,
-              }
-            end
 
+          context 'with force_enable set to false' do
             it { is_expected.to contain_exec('enable_ca_trust').with_command('update-ca-trust enable') }
           end
         end


### PR DESCRIPTION
parameter was moved from ca_cert::update to ca_cert but tests were not

 @pcfens that interface change should have been a major version number
Please only release if the tests are actually ok