### PR TITLE
Use Puppet String data type to check if the variable is a string

### DIFF
--- a/manifests/ca.pp
+++ b/manifests/ca.pp
@@ -52,7 +52,7 @@ define ca_cert::ca (
     $file_mode = $ca_file_mode
   }
 
-  if ($ensure == 'trusted' or $ensure == 'distrusted') and $source == 'text' and !is_string($ca_text) {
+  if ($ensure == 'trusted' or $ensure == 'distrusted') and $source == 'text' and !$ca_text {
     fail('ca_text is required if source is set to text')
   }
 


### PR DESCRIPTION
The purpose of this PR is to get rid of this warning:
```
Warning: This method is deprecated, please use match expressions with Stdlib::Compat::String instead. They are described at https://docs.puppet.com/puppet/latest/reference/lang_data_type.html#match-expressions. at ["/etc/puppetlabs/code/e
nvironments/production/modules/ca_cert/manifests/ca.pp", 47]:
(at /etc/puppetlabs/code/environments/production/modules/stdlib/lib/puppet/functions/deprecation.rb:28:in `deprecation')
```