### PR TITLE
Allow package_ensure to be "latest"

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -45,7 +45,7 @@ class ca_cert (
   Boolean $install_package     = true,
   Boolean $force_enable        = false,
   Hash    $ca_certs            = {},
-  String  $package_ensure      = present,
+  String  $package_ensure      = 'present',
   String  $package_name        = $ca_cert::params::package_name,
 ) inherits ca_cert::params {
 
@@ -74,7 +74,7 @@ class ca_cert (
   }
 
   if $install_package == true {
-    if $package_ensure == present or $package_ensure == installed {
+    if $package_ensure in ['present', 'installed', 'latest'] {
       ensure_packages([$package_name])
       Package[$package_name] -> Ca_cert::Ca <| |>
     }


### PR DESCRIPTION
Treat `ca_cert::package_ensure: 'latest'` the same as the module would `present` or `installed`