### PR TITLE
fix: deleted certs should update-ca-trust

### DIFF
--- a/manifests/ca.pp
+++ b/manifests/ca.pp
@@ -146,6 +146,7 @@ define ca_cert::ca (
     'absent': {
       file { $ca_cert:
         ensure => absent,
+        notify => Class['::ca_cert::update'],
       }
     }
     default: {


### PR DESCRIPTION
Fixes #64

Removing a cert should update-ca-trust.