### PR TITLE
Fix duplicate package declaration issue

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -76,10 +76,8 @@ class ca_cert (
   }
 
   if $install_package {
-    package { 'ca-certificates':
-      ensure => $package_ensure,
-      name   => $package_name,
-    }
+    ensure_packages($package_name, { ensure => $package_ensure })
+
     if $package_ensure != 'absent' {
       Package['ca-certificates'] -> Ca_cert::Ca <| |>
     }


### PR DESCRIPTION
If the package ca-certificates has already been declared someplace else in the codebase that uses ca_cert then this patch will prevent ca_cert from causing a duplicate declaration error.

Of course, one could argue that the user of the ca_cert module should just pass $install_package as false, and you may be right in that. But I see no harm in applying this patch.