### PR TITLE
init: set package_ensure default to 'installed'

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -47,7 +47,7 @@ class ca_cert (
   Boolean $install_package     = true,
   Boolean $force_enable        = false,
   Hash    $ca_certs            = {},
-  String  $package_ensure      = 'present',
+  String  $package_ensure      = 'installed',
   String  $package_name        = $ca_cert::params::package_name,
 ) inherits ca_cert::params {
 


### PR DESCRIPTION
This allows for better compatibility with puppetlabs-stdlib version 8 and use of `ensure_packages('ca-certificates')` (such as the puppet-openssl does) due to https://github.com/puppetlabs/puppetlabs-stdlib/pull/1196. Otherwise you can get a duplicate resource declaration error due to the mismatch in the ensure value.

I think #66 should _also_ be merged.