### PR TITLE
Add support for Solaris 11

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -72,6 +72,21 @@ class ca_cert::params {
       $ca_file_extension   = 'crt'
       $package_name        = 'ca-certificates'
     }
+    'Solaris': {
+      if versioncmp($::operatingsystemmajrelease, '11') >= 0  {
+        $trusted_cert_dir    = '/etc/certs/CA/'
+        $update_cmd          = '/usr/sbin/svcadm restart /system/ca-certificates'
+        $cert_dir_group      = 'sys'
+        $cert_dir_mode       = '0755'
+        $ca_file_group       = 'root'
+        $ca_file_mode        = '0444'
+        $ca_file_extension   = 'pem'
+        $package_name        = 'ca-certificates'
+      }
+      else {
+        fail("Unsupported OS Major release (${::operatingsystemmajrelease})")  
+      }
+    }
     default: {
       fail("Unsupported osfamily (${::osfamily})")
     }


### PR DESCRIPTION
We have some Solaris 11 hosts where this module is handy. 

Documentation from Oracle: https://docs.oracle.com/cd/E53394_01/html/E54783/kmf-cacerts.html 

Tested on:
`$ uname -a
SunOS hostname 5.11 11.4.33.94.0 sun4v sparc sun4v 
`