### PR TITLE
Add RHEL8 to supported operating systems

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -23,7 +23,8 @@
       "operatingsystemrelease": [
         "5",
         "6",
-        "7"
+        "7",
+        "8"
       ]
     },
     {


### PR DESCRIPTION
Tested on RHEL8 (New deployment of the host), had no Problems.

Untested params, but I'm pretty sure that there won't be any problems:
- ca_cert
  - always_update_certs (only used default, false)
  - purge_unmanaged_CAs (only used default, false)
  - install_package (only used default, installed)
- ca_cert::ca
  - ca_text
  - source
    - ftp
    - http(s)
    - file
    - text
  - verify_https_cert
  - checksum

