### PR TITLE
fix: switch to namespaced function stdlib::ensure_packages; require puppetlabs/stdlib 9

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -75,7 +75,7 @@ class ca_cert (
   }
 
   if $install_package {
-    ensure_packages($package_name, { ensure => $package_ensure })
+    stdlib::ensure_packages($package_name, { ensure => $package_ensure })
 
     if $package_ensure != 'absent' {
       Package[$package_name] -> Ca_cert::Ca <| |>

--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 3.0.0 < 10.0.0"
+      "version_requirement": ">= 9.0.0 < 10.0.0"
     },
     {
       "name": "puppet/archive",


### PR DESCRIPTION
This is a rebase of #76 . I also updated the metadata.json to address the new required version.