### PR TITLE
.fixtures.yml: Remove legacy symlink

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,3 +1,4 @@
+---
 fixtures:
   repositories:
     stdlib: "https://github.com/puppetlabs/puppetlabs-stdlib.git"
@@ -6,5 +7,3 @@ fixtures:
     facts: https://github.com/puppetlabs/puppetlabs-facts.git
     provision: https://github.com/puppetlabs/provision.git
     puppet_agent: https://github.com/puppetlabs/puppetlabs-puppet_agent.git
-  symlinks:
-    ca_cert: "#{source_dir}"


### PR DESCRIPTION
We don't need to declare the symlink anymore, puppetlabs_spec_helper will create it for us automatically.